### PR TITLE
Add OTA rollback capabilities for x86

### DIFF
--- a/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/recipes-bsp/grub/grub-efi_%.bbappend
@@ -1,0 +1,2 @@
+# Add regexp command to GRUB
+GRUB_BUILDIN += "regexp"

--- a/recipes-core/base-files/base-files/fstab
+++ b/recipes-core/base-files/base-files/fstab
@@ -1,6 +1,7 @@
 # stock fstab - you probably want to override this with a machine specific one
 
 /dev/root            /                    auto       defaults              1  1
+/dev/sda1            /var/rootdirs/media/efi  vfat   defaults              0  2
 proc                 /proc                proc       defaults              0  0
 devpts               /dev/pts             devpts     mode=0620,ptmxmode=0666,gid=5      0  0
 tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0

--- a/recipes-extended/ostree/files/0001-ostree-grub-generator-allow-adding-custom-scripts-to.patch
+++ b/recipes-extended/ostree/files/0001-ostree-grub-generator-allow-adding-custom-scripts-to.patch
@@ -1,0 +1,56 @@
+From 9db2364ceb4febc3f5d2d13ad798c372920a5e06 Mon Sep 17 00:00:00 2001
+From: Eduardo Ferreira <eduardo.barbosa@toradex.com>
+Date: Thu, 21 Dec 2023 10:04:54 -0300
+Subject: [PATCH] ostree-grub-generator: allow adding custom scripts to
+ grub.cfg
+
+This changes allow us to customize grub.cfg without manually editing it.
+
+Now, whatever files found under /etc/ostree.d are added (in alphabetical
+order) between the cfg header and its menuentries.
+
+Upstream-Status: Pending
+
+Signed-off-by: Eduardo Ferreira <eduardo.barbosa@toradex.com>
+---
+ src/boot/grub2/ostree-grub-generator | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/src/boot/grub2/ostree-grub-generator b/src/boot/grub2/ostree-grub-generator
+index d1436b65..f644fd8a 100644
+--- a/src/boot/grub2/ostree-grub-generator
++++ b/src/boot/grub2/ostree-grub-generator
+@@ -25,6 +25,7 @@ script=$(basename ${0})
+ # Atomically safe location where to generete grub.cfg when executing system upgrade.
+ new_grub2_cfg=${2}
+ entries_path=$(dirname $new_grub2_cfg)/entries
++custom_scripts="/etc/ostree.d"
+ 
+ read_config()
+ {
+@@ -105,10 +106,22 @@ timeout=10
+ EOF
+ }
+ 
++populate_custom_section()
++{
++if [ -d "$custom_scripts" ]; then
++    for script in $(ls -v $custom_scripts/*); do
++        echo -e "\n### BEGIN ${script} ###" >> ${new_grub2_cfg} 
++        cat ${script} >> ${new_grub2_cfg}
++        echo -e "\n### END ${script} ###\n" >> ${new_grub2_cfg}
++    done
++fi
++}
++
+ generate_grub2_cfg()
+ {
+     populate_warning
+     populate_header
++    populate_custom_section
+     populate_menu
+ }
+ 
+-- 
+2.34.1
+

--- a/recipes-extended/ostree/ostree_%.bbappend
+++ b/recipes-extended/ostree/ostree_%.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 inherit bash-completion
 
 SRC_URI:append = " \
+    file://0001-ostree-grub-generator-allow-adding-custom-scripts-to.patch \
     file://0001-update-default-grub-cfg-header.patch \
     file://0002-Add-support-for-the-fdtfile-variable-in-uEnv.txt.patch \
     file://0003-ostree-fetcher-curl-handle-non-404-errors-as-G_IO_ER.patch \
@@ -50,4 +51,6 @@ do_install:append () {
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/ostree-pending-reboot.service ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/ostree-pending-reboot.path ${D}${systemd_system_unitdir}
+
+    install -d ${D}${sysconfdir}/ostree.d
 }

--- a/recipes-images/images/torizon-core-common.inc
+++ b/recipes-images/images/torizon-core-common.inc
@@ -76,6 +76,11 @@ CORE_IMAGE_BASE_INSTALL:append:sota = " \
     provision-device \
 "
 
+# Update fallback for GRUB (for now only on x86 machines)
+CORE_IMAGE_BASE_INSTALL:append:x86-64 = " \
+    grub-ota-fallback \
+"
+
 CORE_IMAGE_BASE_INSTALL:append:mx8-nxp-bsp = " \
     kernel-module-imx-gpu-viv \
 "

--- a/recipes-sota/config/aktualizr-default-sec.bb
+++ b/recipes-sota/config/aktualizr-default-sec.bb
@@ -14,6 +14,7 @@ SRC_URI = " \
 
 RDEPENDS:${PN} += "bash coreutils jq util-linux mmc-utils sed u-boot-fw-utils"
 RDEPENDS:${PN}:remove:genericx86-64 = "u-boot-fw-utils"
+RDEPENDS:${PN}:remove:qemux86-64 = "u-boot-fw-utils"
 RDEPENDS:${PN}:remove:intel-corei7-64 = "u-boot-fw-utils"
 
 do_install:append () {

--- a/recipes-sota/grub-ota-fallback/grub-ota-fallback/99_fallback_logic
+++ b/recipes-sota/grub-ota-fallback/grub-ota-fallback/99_fallback_logic
@@ -1,0 +1,53 @@
+# GRUB can't add, so we hack an increment
+set inc_range="0,1 1,2 2,3"
+function inc_bootcount {
+    set incr=""
+    regexp --set=1:incr "${bootcount},([0-9]+)" "${inc_range}"
+    set bootcount=$incr
+}
+
+function inc_default {
+    set incr=""
+    regexp --set=1:incr "${default},([0-9]+)" "${inc_range}"
+    set default=$incr
+}
+
+# Load all the variables needed
+load_env
+
+if [ "${rollback}" == "0" -a "${upgrade_available}" = "1" ]; then
+    # Make sure to reset default whenever we already performed a rollback
+    # and deployed a new image. This way we'll be able to boot this new image
+    # and test it. If all fails we can still fallback.
+    set default=0
+    save_env default
+fi
+
+if [ "${rollback}" == "1" -a "${upgrade_available}" = "1" ]; then
+    # Make sure to reset upgrade_available to avoid unnecessary wear
+    # Note this also makes rollback permanent. aktualizr will reset rollback
+    # when a new (hopefully better) update comes in.
+    set upgrade_available=0
+    save_env upgrade_available
+fi
+
+if [ "${bootcount}" == "${bootlimit}" ]; then
+    # We've reached our retry limit, marking for OS rollback
+    set rollback=1
+    save_env rollback
+else
+    inc_bootcount
+    save_env bootcount
+fi
+
+if [ "${upgrade_available}" == "1" ]; then
+    if [ "${rollback}" == 1 ]; then
+        # We need to rollback, so we reset 'bootcount' and increase default value.
+        # Since entries are ordered from newest to oldest, increasing default is
+        # rolling back to the last entry.
+        inc_default
+        set bootcount=0
+        save_env default
+        save_env bootcount
+    fi
+fi

--- a/recipes-sota/grub-ota-fallback/grub-ota-fallback/fw_printenv
+++ b/recipes-sota/grub-ota-fallback/grub-ota-fallback/fw_printenv
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Aliasing grub-editenv to U-Boot's fw_setenv
+if [[ $# -ne 1 ]]; then
+    grub-editenv /var/rootdirs/media/efi/EFI/BOOT/grubenv list
+else
+    grub-editenv /var/rootdirs/media/efi/EFI/BOOT/grubenv list | grep "^$1=" || echo "$1="
+fi

--- a/recipes-sota/grub-ota-fallback/grub-ota-fallback/fw_setenv
+++ b/recipes-sota/grub-ota-fallback/grub-ota-fallback/fw_setenv
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Aliasing grub-editenv to U-Boot's fw_setenv
+if [[ $# -eq 2 ]]; then
+    grub-editenv /var/rootdirs/media/efi/EFI/BOOT/grubenv set "$1"="$2"
+fi

--- a/recipes-sota/grub-ota-fallback/grub-ota-fallback/grubenv-create.service
+++ b/recipes-sota/grub-ota-fallback/grub-ota-fallback/grubenv-create.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Check and create grubenv if not present
+After=boot-complete.target
+Requires=boot-complete.target
+ConditionPathExists=|!/var/rootdirs/media/efi/EFI/BOOT/grubenv
+
+[Service]
+Type=oneshot
+WorkingDirectory=/var/rootdirs/media/efi/EFI/BOOT/
+ExecStart=/usr/bin/grub-editenv ./grubenv create ; /usr/bin/grub-editenv ./grubenv set bootcount=0 bootlimit=3 rollback=0 upgrade_available=0
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-sota/grub-ota-fallback/grub-ota-fallback_1.0.bb
+++ b/recipes-sota/grub-ota-fallback/grub-ota-fallback_1.0.bb
@@ -1,0 +1,37 @@
+SUMMARY = "Adds fallback logic to GRUB boot script"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "\
+    file://99_fallback_logic \
+    file://grubenv-create.service \
+    file://fw_printenv \
+    file://fw_setenv \
+"
+
+S = "${WORKDIR}"
+
+inherit systemd
+
+RDEPENDS:${PN} = "bash"
+
+SYSTEMD_SERVICE:${PN} = "grubenv-create.service"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/fw_printenv ${D}${bindir}/fw_printenv
+    install -m 0755 ${WORKDIR}/fw_setenv ${D}${bindir}/fw_setenv
+
+    install -d ${D}${sysconfdir}/ostree.d
+    install -m 0755 ${WORKDIR}/99_fallback_logic ${D}${sysconfdir}/ostree.d/99_fallback_logic
+
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/grubenv-create.service ${D}${systemd_unitdir}/system/grubenv-create.service
+}
+
+FILES:${PN} += "\
+    ${systemd_unitdir}/system/grubenv-create.service \
+    ${bindir}/fw_printenv \
+    ${bindir}/fw_setenv \
+"


### PR DESCRIPTION
Extending ostree-grub-generator script, so that it also checks under
'/etc/ostree.d' for bootloader logic to append to grub.cfg script.

Also create the '/etc/ostree.d' folder in order to store the files to be
appended.

Added regexp module to grub, to create some variable increment functions
since there's no math in Grub.

Added grub-ota-fallback recipe that uses the OSTree change that enables to add custom logic to
grub.cfg. It adds the '99_fallback_logic' to '/etc/ostree.d', so after
an update, if it goes wrong, grub can perform a fallback.

Added the 'grubenv-create' service, a oneshot service that the idea is to
only run in the first boot ever, since it check the BOOT partition for
the grubenv environment file, and if it's not present, it will create
one with the variables used during fallback with their default values.

Added an entry into fstab, so that the BOOT partition is mounted and
ready for both Greenboot and grubenv-create.service to operate on Grub
environment file.

And also adds 2 aliases for 'grubenv-edit' tool, for 'fw_printenv' and
'fw_setenv', so that both Aktualizr and Greenboot become compatible with
Grub.