### PR TITLE
Allow user to override the OTA version on local.conf

### DIFF
--- a/classes/image_type_torizon.bbclass
+++ b/classes/image_type_torizon.bbclass
@@ -40,7 +40,7 @@ TDX_OSTREE_PURPOSE ?= "${@get_tdx_ostree_purpose(d.getVar('TDX_PURPOSE'))}"
 
 # Use new branch naming
 OSTREE_BRANCHNAME = "${TDX_RELEASE}-${MACHINE}"
-GARAGE_TARGET_VERSION = "${TDX_RELEASE}"
+GARAGE_TARGET_VERSION ?= "${TDX_RELEASE}"
 
 # Force ostree summary to be updated
 OSTREE_UPDATE_SUMMARY = "1"


### PR DESCRIPTION
This PR is a suggestion.

The package version is hard assigned. This makes it impossible to override the value on other places like the local.conf file.

Doing a soft assignment instead allows the user to override the OTA version, making it easier to push increments to the user's OTA server from Yocto.